### PR TITLE
Remove @parent references from game_teams_collection and tests

### DIFF
--- a/lib/game_teams_collection.rb
+++ b/lib/game_teams_collection.rb
@@ -5,8 +5,7 @@ class GameTeamsCollection
   include Calculator
 
   attr_reader :game_teams
-  def initialize(game_teams_path, parent)
-    @parent = parent
+  def initialize(game_teams_path)
     @game_teams = create_game_teams(game_teams_path)
   end
 
@@ -14,10 +13,6 @@ class GameTeamsCollection
     CSV.foreach(game_teams_path, headers: true, header_converters: :symbol).map do |row|
       GameTeam.new(row)
     end
-  end
-
-  def find_team_name(id)
-    @parent.find_team_name(id)
   end
 
   def games_by_team
@@ -88,14 +83,9 @@ class GameTeamsCollection
     low(average_home_goals_by_team).first
   end
 
-  def game_ids_by_season(id)
-    @parent.find_season_id(id)
-  end
-
   def wins_by_coach(season_id)
-    game_ids = game_ids_by_season(season_id)
     @game_teams.each_with_object(Hash.new {|h, k| h[k] = {success: 0, total: 0}}) do |game_team, wins|
-      next if !game_ids.include?(game_team.game_id)
+      next unless game_team.game_id[0..3] == season_id[0..3]
       wins[game_team.head_coach][:total] += 1
       wins[game_team.head_coach][:success] += 1 if game_team.result == "WIN"
     end
@@ -110,9 +100,8 @@ class GameTeamsCollection
   end
 
   def shots_by_team_by_season(season_id)
-    game_ids = game_ids_by_season(season_id)
     game_teams.each_with_object(Hash.new {|h, k| h[k] = {success: 0, total: 0}}) do |game_team, stat|
-      next if !game_ids.include?(game_team.game_id)
+      next unless game_team.game_id[0..3] == season_id[0..3]
       stat[game_team.team_id][:success] += game_team.shots
       stat[game_team.team_id][:total] += game_team.goals
     end
@@ -127,9 +116,8 @@ class GameTeamsCollection
   end
 
   def teams_with_tackles(season_id)
-    game_ids = game_ids_by_season(season_id)
     game_teams.each_with_object(Hash.new(0)) do |game_team, teams|
-      next if !game_ids.include?(game_team.game_id)
+      next unless game_team.game_id[0..3] == season_id[0..3]
       teams[game_team.team_id] += game_team.tackles
     end
   end

--- a/lib/games_collection.rb
+++ b/lib/games_collection.rb
@@ -16,16 +16,6 @@ class GamesCollection
     end
   end
 
-  def find_season_id(id)
-    game_ids = []
-    games.find_all do |game|
-      if game.season == id
-        game_ids << game.game_id
-      end
-    end
-    game_ids
-  end
-
   def wins_by_hoa(hoa)
     games.count do |game|
       game.winner == hoa

--- a/lib/season.rb
+++ b/lib/season.rb
@@ -1,0 +1,18 @@
+require_relative './calculator'
+
+class Season
+  include Calculator
+  attr_reader :result
+
+  def initialize(season_id, hash_method, math_method, parent)
+    @parent = parent
+    @game_set = @parent.game_teams_by_season(season_id)
+    @result = (send(math_method, send(hash_method))).first
+  end
+
+  def teams_with_tackles
+    @game_set.each_with_object(Hash.new(0)) do |game_team, teams|
+        teams[game_team.team_id] += game_team.tackles
+    end
+  end
+end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -9,7 +9,7 @@ class StatTracker
   def initialize(locations)
     @teams = TeamsCollection.new(locations[:teams])
     @games = GamesCollection.new(locations[:games])
-    @game_teams = GameTeamsCollection.new(locations[:game_teams], self)
+    @game_teams = GameTeamsCollection.new(locations[:game_teams])
   end
 
   def self.from_csv(locations)
@@ -18,10 +18,6 @@ class StatTracker
 
   def find_team_name(team_id)
     @teams.find_team_name(team_id)
-  end
-
-  def find_season_id(id)
-    @games.find_season_id(id)
   end
 
   def highest_total_score

--- a/test/game_teams_collection_test.rb
+++ b/test/game_teams_collection_test.rb
@@ -4,13 +4,7 @@ require './lib/game_teams_collection'
 class GameTeamsCollectionTest < Minitest::Test
 
   def setup
-    @parent = mock("Collection")
-    # @parent.stubs(:find_team_name, "3").returns("FC Dallas")
-    # @parent.stubs(:find_team_name, "6").returns("Houston Dynamo")
-    @parent.stubs(:find_season_id).returns(["2012030221", "2012030222", "2012030223", "2012030224", "2012030225"])
-    @parent.stubs(:find_team_name, "2012030221").returns("20122013")
-
-    @gameteamcollection = GameTeamsCollection.new('./data/game_teams_dummy.csv', @parent)
+    @gameteamcollection = GameTeamsCollection.new('./data/game_teams_dummy.csv')
   end
 
   def test_it_exists
@@ -20,11 +14,6 @@ class GameTeamsCollectionTest < Minitest::Test
 
   def test_first_game
     assert_instance_of GameTeam, @gameteamcollection.game_teams[0]
-  end
-
-  def test_find_team_name
-
-    assert_equal "20122013", @gameteamcollection.find_team_name("2012030221")
   end
 
   def test_all_games


### PR DESCRIPTION
This branch adds additional tests for the calculator module and removes the last @parent references, which we weren't using. All tests are passing and the spec harness runs in under 1 second.